### PR TITLE
Fix string interpolation and backslash escaping.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 vendor/
 composer.lock
 .php-cs-fixer.cache
+.phpunit.cache
 .idea
+.vscode

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,7 +14,8 @@ return (new Config())
     ->setFinder(
         Finder::create()->in(
             [
-                "src"
+                "src",
+                "tests",
             ]
         )->in(__DIR__)
     )

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,9 @@
         "php": ">=7.4"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.0"
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "phpunit/phpunit": "^9.5",
+        "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2"
     },
     "scripts": {
         "php-cs-fixer-dry-run": "./vendor/bin/php-cs-fixer fix  --config .php-cs-fixer.dist.php --dry-run",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         convertDeprecationsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage cacheDirectory=".phpunit.cache/code-coverage"
+              processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/src/DoubleQuoteFixer.php
+++ b/src/DoubleQuoteFixer.php
@@ -92,9 +92,10 @@ final class DoubleQuoteFixer implements FixerInterface
                 // Stripping extremities of the string (removing the two ')
                 $content = substr($content, 1, -1);
 
-                // Removed escaped ' and $
+                // Removed escaped '
                 $content = str_replace("\\'", "'", $content);
-                $content = str_replace("\\$", "$", $content);
+				// Escape $
+                $content = str_replace("$", "\\$", $content);
 
                 // Replacing the content in the tokens
                 $tokens->clearAt($index);

--- a/src/DoubleQuoteFixer.php
+++ b/src/DoubleQuoteFixer.php
@@ -96,6 +96,8 @@ final class DoubleQuoteFixer implements FixerInterface
                 $content = str_replace("\\'", "'", $content);
 				// Escape $
                 $content = str_replace("$", "\\$", $content);
+				// Escape \
+                $content = str_replace("\\", "\\\\", $content);
 
                 // Replacing the content in the tokens
                 $tokens->clearAt($index);

--- a/tests/DoubleQuoteFixerTest.php
+++ b/tests/DoubleQuoteFixerTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GD75\DoubleQuoteFixer\Tests;
+
+use GD75\DoubleQuoteFixer\DoubleQuoteFixer;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PHPUnit\Framework\TestCase;
+use SplFileInfo;
+
+class DoubleQuoteFixerTest extends TestCase
+{
+    private DoubleQuoteFixer $fixer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fixer = new DoubleQuoteFixer();
+    }
+
+    /**
+     * @dataProvider providerFixDoubleQuote
+     * @covers \GD75\DoubleQuoteFixer\DoubleQuoteFixer
+     */
+    public function testFixDoubleQuote(string $input, string $expectedOutput): void
+    {
+        Tokens::clearCache();
+        $tokens = Tokens::fromCode($input);
+
+        $dummyFile = new SplFileInfo(tempnam(sys_get_temp_dir(), "double_quote_fixer_dummy"));
+
+        $this->fixer->fix($dummyFile, $tokens);
+
+        $tokens->clearEmptyTokens();
+
+        Tokens::clearCache();
+        $expectedTokens = Tokens::fromCode($expectedOutput);
+        static::assertTokens($expectedTokens, $tokens);
+    }
+
+    /**
+     * Copied from PhpCsFixer\Tokenizer\Tokens\AssertTokensTrait (c) Fabien Potencier <fabien@symfony.com>, Dariusz Rumiński <dariusz.ruminski@gmail.com>.
+     */
+    private static function assertTokens(Tokens $expectedTokens, Tokens $inputTokens): void
+    {
+        foreach ($expectedTokens as $index => $expectedToken) {
+            if (!isset($inputTokens[$index])) {
+                static::fail(sprintf("The token at index %d must be:\n%s, but is not set in the input collection.", $index, $expectedToken->toJson()));
+            }
+
+            $inputToken = $inputTokens[$index];
+
+            static::assertTrue(
+                $expectedToken->equals($inputToken),
+                sprintf("The token at index %d must be:\n%s,\ngot:\n%s.", $index, $expectedToken->toJson(), $inputToken->toJson())
+            );
+
+            $expectedTokenKind = $expectedToken->isArray() ? $expectedToken->getId() : $expectedToken->getContent();
+            static::assertTrue(
+                $inputTokens->isTokenKindFound($expectedTokenKind),
+                sprintf(
+                    "The token kind %s (%s) must be found in tokens collection.",
+                    $expectedTokenKind,
+                    \is_string($expectedTokenKind) ? $expectedTokenKind : Token::getNameForId($expectedTokenKind)
+                )
+            );
+        }
+
+        static::assertSame($expectedTokens->count(), $inputTokens->count(), "Both collections must have the same length.");
+    }
+
+    /**
+     * @return iterable<string, array{input: string, output: string}>
+     */
+    public function providerFixDoubleQuote(): iterable
+    {
+        yield "variableEscaped" => [
+            "input" => <<<'PHP'
+                <?php
+                echo '$foobar';
+            PHP,
+            "output" => <<<'PHP'
+                <?php
+                echo "\$foobar";
+            PHP,
+        ];
+        yield "backslashEscaped" => [
+            "input" => <<<'PHP'
+                <?php
+                echo '\foobar';
+            PHP,
+            "output" => <<<'PHP'
+                <?php
+                echo "\\foobar";
+            PHP,
+        ];
+        yield "backslashAndVariableEscaped" => [
+            "input" => <<<'PHP'
+                <?php
+                echo '\$foobar';
+            PHP,
+            "output" => <<<'PHP'
+                <?php
+                echo "\\\$foobar";
+            PHP,
+        ];
+        yield "alreadyEscapedBackslash" => [
+            "input" => <<<'PHP'
+                <?php
+                echo '\\';
+            PHP,
+            "output" => <<<'PHP'
+                <?php
+                echo "\\";
+            PHP,
+        ];
+        yield "alreadyEscapedBackslashWithVariable" => [
+            "input" => <<<'PHP'
+                <?php
+                echo '\\$foobar';
+            PHP,
+            "output" => <<<'PHP'
+                <?php
+                echo "\\\$foobar";
+            PHP,
+        ];
+        yield "unescapeSingleQuote" => [
+            "input" => <<<'PHP'
+                <?php
+                echo '\'';
+            PHP,
+            "output" => <<<'PHP'
+                <?php
+                echo "'";
+            PHP,
+        ];
+        yield "unescapeSingleQuoteAfterBackslash" => [
+            "input" => <<<'PHP'
+                <?php
+                echo '\\\'';
+            PHP,
+            "output" => <<<'PHP'
+                <?php
+                echo "\\'";
+            PHP,
+        ];
+        yield "threeBackslashes" => [
+            "input" => <<<'PHP'
+                <?php
+                echo '\\\foobar';
+            PHP,
+            "output" => <<<'PHP'
+                <?php
+                echo "\\\\foobar";
+            PHP,
+        ];
+        yield "fiveBackslashes" => [
+            "input" => <<<'PHP'
+                <?php
+                echo '\\\\\foobar';
+            PHP,
+            "output" => <<<'PHP'
+                <?php
+                echo "\\\\\\foobar";
+            PHP,
+        ];
+        yield "fiveBackslashesTwice" => [
+            "input" => <<<'PHP'
+                <?php
+                echo '\\\\\foo\\\\\bar';
+            PHP,
+            "output" => <<<'PHP'
+                <?php
+                echo "\\\\\\foo\\\\\\bar";
+            PHP,
+        ];
+        yield "testEscapedNewline" => [
+            "input" => <<<'PHP'
+                <?php
+                echo '\n';
+            PHP,
+            "output" => <<<'PHP'
+                <?php
+                echo "\\n";
+            PHP,
+        ];
+    }
+}


### PR DESCRIPTION
Replacing `\\$` with `$` causes `'\$foobar'` and `'$foobar'` to be changed to `"$foobar"`. Instead, `'\$foobar'` should be changed to `"\\\$foobar"` and `'$foobar'` should be changed to `"\$foobar"`.

Instead of checking for escape sequences that would change the value for a double quoted string, it seems better to just replace every instance of an odd number of backslashes with one extra backslash. Maybe this should be made into a config option?